### PR TITLE
 fix: Improve Activation Margin and Style for Nav Services Dropdown

### DIFF
--- a/src/components/Nav/RegularNav/RegularNav.tsx
+++ b/src/components/Nav/RegularNav/RegularNav.tsx
@@ -73,7 +73,7 @@ const RegularNav: FC<NavProps> = ({ companyLinks, serviceLinks }) => {
             ref={scope}
             onMouseEnter={() => setIsOpen(!isOpen)}
             onMouseLeave={() => setIsOpen(!isOpen)}
-            className="flex flex-col gap-2 hover:cursor-pointer"
+            className="flex flex-col justify-center gap-2 hover:cursor-pointer h-[3em]"
           >
             <motion.button
               whileTap={{ scale: 0.97 }}

--- a/src/components/Nav/RegularNav/RegularNavDropDown.tsx
+++ b/src/components/Nav/RegularNav/RegularNavDropDown.tsx
@@ -21,14 +21,14 @@ const RegularNavDropDown: FC<RegularNavDropDownProps> = ({
         pointerEvents: isOpen ? 'auto' : 'none',
         clipPath: 'inset(10% 50% 90% 50% round 10px)',
       }}
-      className="flex flex-col items-center absolute gap-2 bg-background border-t-4 border-secondarylight top-2/3 -ml-6 mt-1 w-26 p-4 z-40 drop-shadow-lg"
+      className="flex flex-col items-center absolute gap-2 bg-background border-t-4 border-secondarylight top-2/3 -ml-10 mt-2 w-26 p-4 z-40 drop-shadow-lg"
     >
       {serviceLinks.map((link, idx) => (
         <li
           className="manrope-semibold w-full text-center hover:text-primary pb-2 border-b border-secondarylight"
           key={idx}
         >
-          <Link href={link.href} className="txt-sm-semibold hover:text-primary">
+          <Link href={link.href} className="txt-rg-semibold hover:text-primary">
             {link.title}
           </Link>
         </li>


### PR DESCRIPTION
## Description
- **What**: This PR introduces a fix for the Nav Services dropdown to have a larger activation margin and updates the text style for better usability and visibility.
- **Why**: The changes aim to enhance the user experience by making the dropdown easier to activate and the text more readable.

## Changes Made
- **Nav Services Dropdown**:
  - Increased the margin for the activation area to make the dropdown easier to trigger.
  - Updated the text style to be larger for improved readability.

## Related Issues
- None

## Testing
- Verified that the Nav Services dropdown activates more easily with the larger margin.
- Confirmed that the updated text size is consistent with the rest of the site and enhances readability.

## Screenshots
<img width="495" alt="Screen Shot 2024-09-03 at 6 48 32 PM" src="https://github.com/user-attachments/assets/4cc7be6a-48dc-4980-94bb-75af7f5d04b1">

## Additional Notes
- None
