### PR TITLE
feat: Introduce Blog Page with Blog Post Previews

### DIFF
--- a/public/icons/arrow.svg
+++ b/public/icons/arrow.svg
@@ -1,0 +1,12 @@
+<svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_2194_3187)">
+<path d="M5 12.7441H19" stroke="#6126D8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15 16.7441L19 12.7441" stroke="#6126D8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15 8.74414L19 12.7441" stroke="#6126D8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_2194_3187">
+<rect width="24" height="24" fill="white" transform="translate(0 0.744141)"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,13 @@
+import { Metadata } from 'next';
+
+import BlogPageContent from '@/components/BlogPage/BlogPageContent';
+
+export const metadata: Metadata = {
+  title: 'Tag Operations | Blog',
+  description:
+    'Discover expert insights on operations support, including the rise of fractional work and the risks of siloed technology. Learn how to optimize workflows, enhance workforce flexibility, and integrate seamless systems for improved business efficiency and growth.',
+};
+
+export default function BlogPage() {
+  return <BlogPageContent />;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -257,6 +257,34 @@ h4,
   padding: 0 20px;
 }
 
+.blog-card-link::after {
+  position: absolute;
+  content: "";
+  width: 0;
+  left: 0;
+  bottom: -7px;
+  background: var(--primary);
+  height: 2px;
+  transition: 0.2s ease-out;
+}
+
+.blog-card-link {
+  transition-delay: 0.2s;
+}
+
+.blog-card-link:hover::after {
+  width: 100%;
+}
+
+.blog-card-link:hover .blog-card-arrow {
+  transform: translateX(4px);
+}
+
+.blog-card-arrow {
+  transition: 0.2s;
+  transition-delay: 0.2s;
+}
+
 @media (max-width: 500px) {
   .blob-top-small {
     top: 0.8rem;

--- a/src/components/BlogPage/BlogCards.tsx
+++ b/src/components/BlogPage/BlogCards.tsx
@@ -1,0 +1,74 @@
+'use client';
+import { FC } from 'react';
+
+import { motion, Variants } from 'framer-motion';
+
+const cardVariants: Variants = {
+  offscreen: {
+    x: 200,
+    opacity: 0,
+  },
+  onscreen: {
+    x: 0,
+    opacity: 1,
+    transition: {
+      type: 'spring',
+      bounce: 0.4,
+      duration: 0.8,
+    },
+  },
+};
+
+const blogCardsData = [
+  {
+    title: 'The Hidden Dangers of Siloed Technology in Your Company',
+    description:
+      'Uncover the risks of siloed technology in your company, including inefficiencies and security vulnerabilities. Learn how breaking down these silos can improve workflows, collaboration, and innovation.',
+    href: '/blog/1',
+  },
+  {
+    title: 'Embracing the Future: The Rise of Fractional Work',
+    description:
+      "Learn how fractional work is transforming careers and workforce structures, offering flexibility for individuals and strategic advantages for companies in today's evolving professional landscape.",
+    href: '/blog/2',
+  },
+];
+
+const BlogCards: FC = () => {
+  return (
+    <div className="flex flex-wrap md:w-full lg:w-full 2xl:w-3/5 justify-center gap-6 mx-5">
+      {blogCardsData.map((card, idx) => (
+        <motion.div
+          key={idx}
+          variants={cardVariants}
+          initial="offscreen"
+          whileInView="onscreen"
+          viewport={{
+            once: true,
+            amount: 0.4,
+          }}
+          className="flex flex-col justify-between p-4 bg-accentlight rounded-xl drop-shadow w-full md:w-1/4 gap-4"
+        >
+          <div className="flex flex-col gap-4">
+            <p className="txt-md-bold">{card.title}</p>
+            <p className="txt-rg">{card.description}</p>
+          </div>
+
+          <div className="flex gap-2 w-fit relative hover:cursor-pointer blog-card-link">
+            <a href={card.href} className="text-primary txt-rg">
+              Read
+            </a>
+            <img
+              src="/icons/arrow.svg"
+              width={20}
+              height={20}
+              className="blog-card-arrow"
+            />
+          </div>
+        </motion.div>
+      ))}
+    </div>
+  );
+};
+
+export default BlogCards;

--- a/src/components/BlogPage/BlogPageContent.tsx
+++ b/src/components/BlogPage/BlogPageContent.tsx
@@ -1,0 +1,17 @@
+import { FC } from 'react';
+
+import Header from './Header';
+import BlogCards from './BlogCards';
+import ClientsServed from '../ClientsServed/ClientsServed';
+
+const BlogPageContent: FC = () => {
+  return (
+    <main className="flex flex-col items-center w-full gap-8 md:gap-10 relative">
+      <Header />
+      <BlogCards />
+      <ClientsServed />
+    </main>
+  );
+};
+
+export default BlogPageContent;

--- a/src/components/BlogPage/Header.tsx
+++ b/src/components/BlogPage/Header.tsx
@@ -1,0 +1,11 @@
+import { FC } from 'react';
+
+const Header: FC = () => {
+  return (
+    <section className="w-full flex flex-col items-center sm:mt-8 p-6 md:w-2/3 2xl:w-1/2">
+      <h1>Blog</h1>
+    </section>
+  );
+};
+
+export default Header;

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -20,6 +20,7 @@ const navProps = {
     { title: 'About Us', href: '/about' },
     { title: 'Case Studies', href: '/case-studies' },
     { title: 'Pricing', href: '/pricing' },
+    { title: 'Blog', href: '/blog' },
   ],
   serviceLinks: [
     { title: 'Operations', href: '/operations' },


### PR DESCRIPTION
## Description
This PR introduces a new blog page to the app, showcasing a preview of all the blog posts. It includes the creation of a BlogPage component, styling updates, and the addition of a blog link to the navigation.

## Changes Made
### Blog Page
- **New Blog Page**: Added a dedicated Blog Page that displays previews of all blog posts.
- **BlogPage Directory Component**: Created a `BlogPage` directory component to render different parts of the Blog Page.
- **Blog Card Link Asset**: Included an arrow asset for the blog card link to enhance navigation.

### Global CSS
- **Blog Card Link Styling**: Added CSS for the blog card link, featuring an underline that slides out on hover for a more interactive user experience.

### Nav
- **Blog Link**: Added a link to the Blog Page in the navigation for easy access.

## Screenshots

<img width="1470" alt="Screen Shot 2024-09-18 at 2 50 24 PM" src="https://github.com/user-attachments/assets/0a20a4b5-56e3-420c-9d5c-c365f935a9e8">

